### PR TITLE
Tested that courses are returned (or not) when user is logged in (or …

### DIFF
--- a/hammock/app/controllers/courses_controller.rb
+++ b/hammock/app/controllers/courses_controller.rb
@@ -1,7 +1,7 @@
 class CoursesController < ApplicationController
-  # before_action :authenticate_user!
+  before_action :authenticate_user!
 
   def index
-    render json: Course.all
+    render json: Course.where(user_id: current_user.id)
   end
 end

--- a/hammock/app/models/course.rb
+++ b/hammock/app/models/course.rb
@@ -1,2 +1,4 @@
 class Course < ActiveRecord::Base
+
+  belongs_to :user 
 end

--- a/hammock/app/models/user.rb
+++ b/hammock/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ActiveRecord::Base
           :recoverable, :rememberable, :trackable, :validatable,
           :confirmable, :omniauthable
   include DeviseTokenAuth::Concerns::User
+  has_many :courses
 
   before_save -> do
     self.uid = SecureRandom.uuid

--- a/hammock/db/migrate/20160324160522_add_user_id_to_courses.rb
+++ b/hammock/db/migrate/20160324160522_add_user_id_to_courses.rb
@@ -1,0 +1,5 @@
+class AddUserIdToCourses < ActiveRecord::Migration
+  def change
+    add_reference :courses, :user, index: true, foreign_key: true
+  end
+end

--- a/hammock/db/schema.rb
+++ b/hammock/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160322152512) do
+ActiveRecord::Schema.define(version: 20160324160522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,10 @@ ActiveRecord::Schema.define(version: 20160322152512) do
     t.datetime "enddate"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.integer  "user_id"
   end
+
+  add_index "courses", ["user_id"], name: "index_courses_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "provider",               default: "email", null: false
@@ -73,4 +76,5 @@ ActiveRecord::Schema.define(version: 20160322152512) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true, using: :btree
 
+  add_foreign_key "courses", "users"
 end

--- a/hammock/spec/factories/course.rb
+++ b/hammock/spec/factories/course.rb
@@ -1,13 +1,14 @@
 FactoryGirl.define do
   factory :course do
-    provider "MyString"
-    name "MyString"
-    description "MyString"
-    organisation "MyString"
-    image "MyString"
-    url "MyString"
-    duration "MyString"
-    startdate "MyString"
-    enddate "MyString"
+    provider "Coursera"
+    name "Ruby"
+    description "Program in Ruby"
+    organisation "ANUx"
+    image "/c4x/ANUx/ANU-INDIA1x/asset/homepage_course_image.jpg"
+    url "https://courses.edx.org/api/course_structure/v0/courses/ANUx/ANU-INDIA1x/1T2014/"
+    duration "3 months"
+    startdate "2016-03-23T00:00:00.000Z"
+    enddate "2016-06-23T00:00:00.000Z"
+
   end
 end

--- a/hammock/spec/requests/courses/courses_spec.rb
+++ b/hammock/spec/requests/courses/courses_spec.rb
@@ -1,31 +1,68 @@
 describe "Courses API" do
 
   it "sends course list as json" do
-    FactoryGirl.create :course, provider: 'Coursera', name: 'Ruby', description: 'Program in Ruby',
-                      organisation: "ANUx", image: "/c4x/ANUx/ANU-INDIA1x/asset/homepage_course_image.jpg",
-                      url: "https://courses.edx.org/api/course_structure/v0/courses/ANUx/ANU-INDIA1x/1T2014/",
-                      duration: "3 months", startdate: "2016-03-23T00:00:00.000Z", enddate: "2016-06-23T00:00:00.000Z"
-    get "/", {}, { "Accept" => "application/json" }
+    course = FactoryGirl.build :course
+    user = FactoryGirl.create :user
+    course.user_id = user.id
+    course.save
+
+    @auth_headers = user.create_new_auth_token
+
+    get "/courses", {}, @auth_headers
     expect(response.status).to eq 200
+
     body = JSON.parse(response.body)
     provider = body.map { |m| m["provider"] }
     expect(provider).to include 'Coursera'
+
     name = body.map { |m| m["name"] }
     expect(name).to include 'Ruby'
+
     description = body.map { |m| m["description"] }
     expect(description).to include 'Program in Ruby'
+
     organisation = body.map { |m| m["organisation"] }
     expect(organisation).to include 'ANUx'
+
     image = body.map { |m| m["image"] }
     expect(image).to include '/c4x/ANUx/ANU-INDIA1x/asset/homepage_course_image.jpg'
+
     url = body.map { |m| m["url"] }
     expect(url).to include "https://courses.edx.org/api/course_structure/v0/courses/ANUx/ANU-INDIA1x/1T2014/"
+
     duration = body.map { |m| m["duration"] }
     expect(duration).to include '3 months'
+
     startdate = body.map { |m| m["startdate"] }
     expect(startdate).to include "2016-03-23T00:00:00.000Z"
+
     enddate = body.map { |m| m["enddate"] }
     expect(enddate).to include "2016-06-23T00:00:00.000Z"
+  end
+
+  it "returns more than once course when the user has more than one course" do
+    user = FactoryGirl.create :user
+
+    course1 = FactoryGirl.build :course
+    course2 = FactoryGirl.build :course
+
+    course1.user_id = user.id
+    course2.user_id = user.id
+    course1.save
+    course2.save
+
+    @auth_headers = user.create_new_auth_token
+
+    get "/courses", {}, @auth_headers
+    expect(response.status).to eq 200
+
+    body = JSON.parse(response.body)
+    expect(body.length).to eq (2)
+  end
+
+  it "returns an error if the user is not signed in" do
+    get "/courses", {}, @auth_headers
+    expect(response.status).to eq 401
   end
 
 end

--- a/hammock/spec/requests/users/authentication_spec.rb
+++ b/hammock/spec/requests/users/authentication_spec.rb
@@ -23,7 +23,6 @@ describe 'Users API'  do
       expect(response).to be_success
       expect(header.has_key?("access-token")).to eq(true)
       expect(json["data"]["email"]).to eq(user.email)
-      p user
     end
 
     it " doesn't log in a user with invalid inputs" do

--- a/hammock/spec/requests/users/signout_spec.rb
+++ b/hammock/spec/requests/users/signout_spec.rb
@@ -10,21 +10,23 @@ describe 'Users API'  do
         email: @user.email,
         password: @user.password
       }
+      @auth_headers = @user.create_new_auth_token
     end
 
     it 'logs out a user with valid inputs' do
-      post '/auth/sign_in', @user_params
-      delete '/auth/sign_out'
+      # post '/auth/sign_in', @user_params
+      delete '/auth/sign_out', {}, @auth_headers
       json = JSON.parse(response.body)
       header = response.header
+      expect(response).to be_success
     end
 
-    # it " doesn't log in a user with invalid inputs" do
-    #   post '/auth/sign_in', @invalid_user_params
-    #   json = JSON.parse(response.body)
-    #   expect(response).not_to be_success
-    #   expect(json["errors"][0]).to eq ("Invalid login credentials. Please try again.")
-    # end
+    it "doesn't log out a user with invalid inputs" do
+      delete '/auth/sign_out'
+      json = JSON.parse(response.body)
+      expect(response).not_to be_success
+      expect(json["errors"][0]).to eq ("User was not found or was not logged in.")
+    end
 
   end
 


### PR DESCRIPTION
…not)

Added tests for the GET /courses API endpoint to tests that it returns only the courses of the logged in User, and returns a 401 error if the user is not logged in.

Also built out the tests for User signout (already implemented by devise).

Closes #4
