### PR TITLE
9 get courses

### DIFF
--- a/hammock/Gemfile
+++ b/hammock/Gemfile
@@ -7,6 +7,9 @@ gem 'omniauth'
 
 gem 'rack-cors', :require => 'rack/cors'
 
+gem 'faker'
+
+
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.6'

--- a/hammock/Rakefile
+++ b/hammock/Rakefile
@@ -4,3 +4,23 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+namespace :db do
+  namespace :load do
+
+    desc 'Load Coursera Courses from the API'
+    task coursera_courses: :environment do
+        puts "Loading Coursera courses, may take a few seconds..."
+       Courseitem.add_coursera_courses
+       puts 'Done!'
+    end
+
+    desc 'Load Udacity Courses from the API'
+    task udacity_courses: :environment do
+      puts "Loading Udacity courses, may take a few seconds..."
+      Courseitem.add_udacity_courses
+      puts 'Done!'
+    end
+
+  end
+end

--- a/hammock/app/controllers/courseitems_controller.rb
+++ b/hammock/app/controllers/courseitems_controller.rb
@@ -1,2 +1,9 @@
 class CourseitemsController < ApplicationController
+  before_action :authenticate_user!
+
+
+  def index
+    render json: Courseitem.all
+  end
+
 end

--- a/hammock/spec/factories/courseitem.rb
+++ b/hammock/spec/factories/courseitem.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :courseitem do
     provider "EdX"
-    name "A random MOOC"
-    description "Program in Ruby"
+    name Faker::Hipster.sentence
+    description Faker::Hipster.paragraph
     organisation "ANUx"
     image "/c4x/ANUx/ANU-INDIA1x/asset/homepage_course_image.jpg"
     url "https://courses.edx.org/api/course_structure/v0/courses/ANUx/ANU-INDIA1x/1T2014/"

--- a/hammock/spec/requests/course_items.rb/course_items_spec.rb
+++ b/hammock/spec/requests/course_items.rb/course_items_spec.rb
@@ -1,0 +1,31 @@
+describe 'Courseitems API' do
+
+  describe 'GET /courseitems' do
+
+    it 'returns a JSON payload of course items' do
+      user = FactoryGirl.create :user
+      courseitem = FactoryGirl.create :courseitem
+      auth_headers = user.create_new_auth_token
+
+      get "/courseitems", {}, auth_headers
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      provider = body.map { |m| m["provider"] }
+      expect(provider).to include courseitem.provider
+    end
+
+    it 'returns all courseitems in the database' do
+      user = FactoryGirl.create :user
+      courseitem_one = FactoryGirl.create :courseitem
+      courseitem_two = FactoryGirl.create :courseitem
+      auth_headers = user.create_new_auth_token
+
+      get "/courseitems", {}, auth_headers
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      expect(body.length).to eq((Courseitem.all.count))
+    end
+
+  end
+
+end

--- a/hammock/spec/requests/courses/courses_spec.rb
+++ b/hammock/spec/requests/courses/courses_spec.rb
@@ -75,8 +75,6 @@ describe "Courses API" do
     }.to_json
     post "/courses", course_params, auth_headers
     expect(response.status).to eq 201
-    p Courseitem.last
-    p Course.last
     expect(Course.last.name).to eq courseitem.name
     expect(Course.last.provider).to eq courseitem.provider
     expect(Course.last.user_id).to eq user.id


### PR DESCRIPTION
Set up the GET routes for Courseitems, which currently returns all course(catalogue) items as a JSON string.

Also set up Rake tasks for populating the database from the API's:
- rake db:load:coursera_courses - loads all Coursera courses
- rake db:load:udacity_courses - loads all Udacity courses

Squirrel me up!

Closes #9
