### PR TITLE
CourseModule resource created and GET, POST and PUT routes created

### DIFF
--- a/hammock/app/assets/javascripts/course_modules.coffee
+++ b/hammock/app/assets/javascripts/course_modules.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/hammock/app/assets/stylesheets/course_modules.scss
+++ b/hammock/app/assets/stylesheets/course_modules.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the course_modules controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/hammock/app/controllers/course_modules_controller.rb
+++ b/hammock/app/controllers/course_modules_controller.rb
@@ -1,0 +1,32 @@
+class CourseModulesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    render json: CourseModule.where(course_id: params[:course_id])
+  end
+
+  def create
+    @course_module = CourseModule.new(module_params)
+    @course_module.course_id = params[:course_id]
+    if @course_module.save
+      render json: @course_module, status: :created, location: @course_module
+    else
+      render json: @course.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @course_module = CourseModule.find(params[:id])
+    if @course_module.update_attributes(module_params)
+      render json: @course_module, status: :created, location: @course_module
+    else
+      render json: @course_module.errors, status: :unprocessable_entity
+    end
+  end
+
+
+  def module_params
+    params.require(:course_module).permit(:title, :id, :complete)
+  end
+
+end

--- a/hammock/app/helpers/course_modules_helper.rb
+++ b/hammock/app/helpers/course_modules_helper.rb
@@ -1,0 +1,2 @@
+module CourseModulesHelper
+end

--- a/hammock/app/models/course.rb
+++ b/hammock/app/models/course.rb
@@ -1,6 +1,7 @@
 class Course < ActiveRecord::Base
 
   belongs_to :user
+  has_many :course_modules
   after_initialize :init
 
 

--- a/hammock/app/models/course_module.rb
+++ b/hammock/app/models/course_module.rb
@@ -1,0 +1,4 @@
+class CourseModule < ActiveRecord::Base
+
+  belongs_to :course
+end

--- a/hammock/config/routes.rb
+++ b/hammock/config/routes.rb
@@ -1,7 +1,13 @@
 Rails.application.routes.draw do
+
   mount_devise_token_auth_for 'User', at: 'auth'
+
   root 'courses#index'
-  resources :courses
+
+  resources :courses, shallow: true do
+    resources :course_modules
+  end
 
   resources :courseitems
+
 end

--- a/hammock/db/migrate/20160327132601_create_course_modules.rb
+++ b/hammock/db/migrate/20160327132601_create_course_modules.rb
@@ -1,0 +1,10 @@
+class CreateCourseModules < ActiveRecord::Migration
+  def change
+    create_table :course_modules do |t|
+      t.string :title
+      t.boolean :complete
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/hammock/db/migrate/20160327132830_add_course_id_to_course_modules.rb
+++ b/hammock/db/migrate/20160327132830_add_course_id_to_course_modules.rb
@@ -1,0 +1,5 @@
+class AddCourseIdToCourseModules < ActiveRecord::Migration
+  def change
+    add_reference :course_modules, :course, index: true, foreign_key: true
+  end
+end

--- a/hammock/db/schema.rb
+++ b/hammock/db/schema.rb
@@ -11,10 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160325215942) do
+ActiveRecord::Schema.define(version: 20160327132830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "course_modules", force: :cascade do |t|
+    t.string   "title"
+    t.boolean  "complete"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer  "course_id"
+  end
+
+  add_index "course_modules", ["course_id"], name: "index_course_modules_on_course_id", using: :btree
 
   create_table "courseitems", force: :cascade do |t|
     t.string   "provider"
@@ -77,5 +87,6 @@ ActiveRecord::Schema.define(version: 20160325215942) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true, using: :btree
 
+  add_foreign_key "course_modules", "courses"
   add_foreign_key "courses", "users"
 end

--- a/hammock/db/seeds.rb
+++ b/hammock/db/seeds.rb
@@ -24,9 +24,26 @@ courses = [{
   "id": "3"
   }]
 
+course_modules = [{
+    "title": "sign up for the course",
+    "complete": true
+  },
+  {
+    "title": "Complete work for week 1",
+    "complete": false
+  },
+  {
+    "title": "Read up on programming",
+    "complete": false
+  }]
+
 
 @user = User.create!(email: 'email@email.com', password: 'password', password_confirmation: 'password', confirmed_at: Time.zone.now, name: 'Emma' )
 
 courses.each do |course|
   course = Course.create!(name: course[:name], provider: course[:provider], status: course[:status], user_id: @user.id)
+end
+
+course_modules.each do |course_module|
+  CourseModule.create!(title: course_module[:title], complete: course_module[:complete], course_id: 2)
 end

--- a/hammock/spec/factories/course_module.rb
+++ b/hammock/spec/factories/course_module.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :course_module do
+    title Faker::Hipster.sentence
+    complete false
+  end
+end

--- a/hammock/spec/models/course_module_spec.rb
+++ b/hammock/spec/models/course_module_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe CourseModule, type: :model do
+  it { is_expected.to belong_to :course }
+end

--- a/hammock/spec/models/course_spec.rb
+++ b/hammock/spec/models/course_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe Course, type: :model do
+
+  it { is_expected.to have_many :course_modules }
+
+  it 'is expected to initialize with a default status of interested' do
+    course = FactoryGirl.create :course
+    expect(course.status).to eq ("interested")
+  end
+
+end

--- a/hammock/spec/requests/modules/modules_GET_spec.rb
+++ b/hammock/spec/requests/modules/modules_GET_spec.rb
@@ -1,0 +1,42 @@
+describe 'Modules API' do
+
+  describe 'GET /courses/:course_id/course_modules' do
+
+    it 'returns the modules of the course' do
+      user = FactoryGirl.create :user
+      course = FactoryGirl.build :course
+      course_module = FactoryGirl.build :course_module
+      course.user_id = user.id
+      course.save
+      course_module.course_id = course.id
+      course_module.save
+
+      auth_headers = user.create_new_auth_token
+
+      get "/courses/#{course.id}/course_modules", {}, auth_headers
+      expect(response.status).to eq 200
+
+      body = JSON.parse(response.body)
+      expect(body[0]["title"]).to eq course_module.title
+    end
+
+    it 'returns multiple modules if a course has several modules' do
+      user = FactoryGirl.create :user
+      course = FactoryGirl.build :course
+      course.user_id = user.id
+      course.save
+      course_modules = [(FactoryGirl.build :course_module), (FactoryGirl.build :course_module)]
+      course_modules.each do |course_module|
+        course_module.course_id = course.id
+        course_module.save
+      end
+      auth_headers = user.create_new_auth_token
+      get "/courses/#{course.id}/course_modules", {}, auth_headers
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      expect(body.length).to eq(2)
+    end
+
+  end
+
+end

--- a/hammock/spec/requests/modules/modules_POST_spec.rb
+++ b/hammock/spec/requests/modules/modules_POST_spec.rb
@@ -1,0 +1,26 @@
+describe 'Modules API' do
+
+  describe 'POST /courses/:course_id/course_modules' do
+
+
+    it "adds a course" do
+      user = FactoryGirl.create :user
+      course = FactoryGirl.build :course
+      course.user_id = user.id
+      course.save
+      auth_headers = user.create_new_auth_token
+      auth_headers["Content-Type"] = 'application/json'
+      course_module_params = {
+        "course_module" => {
+          "title": "Do some reading",
+          "complete": false
+        }
+      }.to_json
+      post "/courses/#{course.id}/course_modules", course_module_params, auth_headers
+      expect(response.status).to eq 201
+      expect(CourseModule.last.title).to eq "Do some reading"
+      expect(CourseModule.last.complete).to eq false
+    end
+
+  end
+end

--- a/hammock/spec/requests/modules/modules_PUT_spec.rb
+++ b/hammock/spec/requests/modules/modules_PUT_spec.rb
@@ -1,0 +1,29 @@
+describe 'Modules API' do
+
+  describe 'PUT /course_modules/:id' do
+
+    it "updates a course" do
+      user = FactoryGirl.create :user
+      course = FactoryGirl.build :course
+      course.user_id = user.id
+      course.save
+      course_module = FactoryGirl.build :course_module
+      course_module.course_id = course.id
+      course_module.save
+      auth_headers = user.create_new_auth_token
+      auth_headers["Content-Type"] = 'application/json'
+      course_module_params = {
+        "course_module" => {
+          "id": course_module.id,
+          "title": course_module.title,
+          "complete": true
+        }
+      }.to_json
+      put "/course_modules/#{course_module.id}", course_module_params, auth_headers
+      expect(response.status).to eq 201
+      expect(CourseModule.last.id).to eq course_module.id
+      expect(CourseModule.last.complete).to eq true
+    end
+
+  end
+end


### PR DESCRIPTION
Created the course_modules resource which has a many to one relationship with courses. the course_module schema is;

title: string
complete: boolean
course_id: number

Created the following routes:
- GET '/courses/:course_id/course_modules' - returns all course modules associated with the course as JSON
- POST '/courses/:course_id/course_modules' - creates a new course_module resource associated with the specified course
- PUT '/course_modules/:id' - updates the course_module resource based on the id specified

All tested - and also a couple of additional tests added for the course and course_module models.
