### PR TITLE
Delete modules courses

### DIFF
--- a/hammock/app/controllers/course_modules_controller.rb
+++ b/hammock/app/controllers/course_modules_controller.rb
@@ -18,7 +18,16 @@ class CourseModulesController < ApplicationController
   def update
     @course_module = CourseModule.find(params[:id])
     if @course_module.update_attributes(module_params)
-      render json: @course_module, status: :created, location: @course_module
+      render json: @course_module, status: :accepted, location: @course_module
+    else
+      render json: @course_module.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @course_module = CourseModule.find(params[:id])
+    if @course_module.destroy
+      render json: {}, status: :no_content
     else
       render json: @course_module.errors, status: :unprocessable_entity
     end

--- a/hammock/app/controllers/courses_controller.rb
+++ b/hammock/app/controllers/courses_controller.rb
@@ -26,6 +26,15 @@ class CoursesController < ApplicationController
     end
   end
 
+  def destroy
+    @course = Course.find(course_params[:id])
+    if @course.destroy
+      render json: {}, status: :no_content
+    else
+      render json: @course.errors, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def course_params

--- a/hammock/spec/requests/courses/courses_DELETE_spec.rb
+++ b/hammock/spec/requests/courses/courses_DELETE_spec.rb
@@ -1,0 +1,24 @@
+describe 'Courses API' do
+
+  describe 'DELETE /courses/:id' do
+
+    it "deletes a course" do
+      user = FactoryGirl.create :user
+      course = FactoryGirl.build :course
+      course.user_id = user.id
+      course.save
+      auth_headers = user.create_new_auth_token
+      auth_headers["Content-Type"] = 'application/json'
+      course_params = {
+        "course":{
+          "id": course.id
+        }
+      }.to_json
+      delete "/courses/#{course.id}", course_params, auth_headers
+      expect(response.status).to eq 204
+      expect(Course.exists?(course.id)).to eq false
+    end
+
+  end
+
+end

--- a/hammock/spec/requests/modules/modules_DELETE_spec.rb
+++ b/hammock/spec/requests/modules/modules_DELETE_spec.rb
@@ -1,8 +1,8 @@
 describe 'Modules API' do
 
-  describe 'PUT /course_modules/:id' do
+  describe 'DELETE /course_modules/:id' do
 
-    it "updates a course" do
+    it "deletes a course_module" do
       user = FactoryGirl.create :user
       course = FactoryGirl.build :course
       course.user_id = user.id
@@ -19,10 +19,9 @@ describe 'Modules API' do
           "complete": true
         }
       }.to_json
-      put "/course_modules/#{course_module.id}", course_module_params, auth_headers
-      expect(response.status).to eq 202
-      expect(CourseModule.last.id).to eq course_module.id
-      expect(CourseModule.last.complete).to eq true
+      delete "/course_modules/#{course_module.id}", course_module_params, auth_headers
+      expect(response.status).to eq 204
+      expect(CourseModule.exists?(course_module.id)).to eq false
     end
 
   end


### PR DESCRIPTION
Created two new routes in the backend API;
-  DELETE '/course_modules/:id' - will delete the specified course_module, expects to receive the id of the course_module to delete
- DELETE '/courses/:id' - will delete the specified course, expects to receive the id of the course to delete
