### PR TITLE
Clone check courseitem

### DIFF
--- a/hammock/Gemfile
+++ b/hammock/Gemfile
@@ -10,6 +10,10 @@ gem 'rack-cors', :require => 'rack/cors'
 gem 'httparty'
 gem 'faker'
 
+gem 'rabl'
+# Also add either `oj` or `yajl-ruby` as the JSON parser
+gem 'oj'
+
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.6'

--- a/hammock/Gemfile.lock
+++ b/hammock/Gemfile.lock
@@ -112,11 +112,14 @@ GEM
     multi_xml (0.5.5)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    oj (2.14.6)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
     orm_adapter (0.5.0)
     pg (0.18.4)
+    rabl (0.12.0)
+      activesupport (>= 2.3.14)
     rack (1.6.4)
     rack-cors (0.4.0)
     rack-test (0.6.3)
@@ -240,8 +243,10 @@ DEPENDENCIES
   httparty
   jbuilder (~> 2.0)
   jquery-rails
+  oj
   omniauth
   pg (~> 0.15)
+  rabl
   rack
   rack-cors
   rails (= 4.2.6)

--- a/hammock/app/controllers/courseitems_controller.rb
+++ b/hammock/app/controllers/courseitems_controller.rb
@@ -1,9 +1,12 @@
 class CourseitemsController < ApplicationController
   before_action :authenticate_user!
 
+  respond_to :json
+
 
   def index
-    render json: Courseitem.all
+    @courseitems = Courseitem.all
+    @user = current_user
   end
 
 end

--- a/hammock/app/models/courseitem.rb
+++ b/hammock/app/models/courseitem.rb
@@ -1,3 +1,7 @@
 class Courseitem < ActiveRecord::Base
 
+  def cloned_by_current_user?(user)
+    user.courses.any? {|course| course.name == self.name }
+  end
+
 end

--- a/hammock/app/views/courseitems/index.rabl
+++ b/hammock/app/views/courseitems/index.rabl
@@ -1,0 +1,3 @@
+collection @courseitems
+attributes :provider, :name, :description, :organisation, :image, :url, :status, :id
+node(:cloned) { |courseitem| courseitem.cloned_by_current_user?(@user) }

--- a/hammock/config/initializers/rabl_init.rb
+++ b/hammock/config/initializers/rabl_init.rb
@@ -1,0 +1,27 @@
+require 'rabl'
+Rabl.configure do |config|
+  # Commented as these are defaults
+  # config.cache_all_output = false
+  # config.cache_sources = Rails.env != 'development' # Defaults to false
+  # config.cache_engine = Rabl::CacheEngine.new # Defaults to Rails cache
+  # config.perform_caching = false
+  # config.escape_all_output = false
+  # config.json_engine = nil # Class with #dump class method (defaults JSON)
+  # config.msgpack_engine = nil # Defaults to ::MessagePack
+  # config.bson_engine = nil # Defaults to ::BSON
+  # config.plist_engine = nil # Defaults to ::Plist::Emit
+  config.include_json_root = false
+  # config.include_msgpack_root = true
+  # config.include_bson_root = true
+  # config.include_plist_root = true
+  # config.include_xml_root  = false
+  # config.include_child_root = true
+  # config.enable_json_callbacks = false
+  # config.xml_options = { :dasherize  => true, :skip_types => false }
+  # config.view_paths = []
+  # config.raise_on_missing_attribute = true # Defaults to false
+  # config.replace_nil_values_with_empty_strings = true # Defaults to false
+  # config.replace_empty_string_values_with_nil_values = true # Defaults to false
+  # config.exclude_nil_values = true # Defaults to false
+  # config.exclude_empty_values_in_collections = true # Defaults to false
+end

--- a/hammock/spec/factories/courseitem.rb
+++ b/hammock/spec/factories/courseitem.rb
@@ -8,6 +8,5 @@ FactoryGirl.define do
     url "https://courses.edx.org/api/course_structure/v0/courses/ANUx/ANU-INDIA1x/1T2014/"
     startdate "2016-03-23T00:00:00.000Z"
     enddate "2016-06-23T00:00:00.000Z"
-
   end
 end

--- a/hammock/spec/models/courseitem_spec.rb
+++ b/hammock/spec/models/courseitem_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe Courseitem, type: :model do
+
+  describe '#cloned_by_current_user?' do
+
+    let(:user) {FactoryGirl.create :user}
+    let(:courseitem){ FactoryGirl.create :courseitem}
+
+
+    it 'returns true if the current user has a course cloned from the courseitem' do
+      course = Course.build_with_clone(courseitem, user)
+      course.save
+      expect(courseitem.cloned_by_current_user?(user)).to eq true
+    end
+
+    it 'returns false if the current user does not have a course cloned from the courseitem' do
+      course = FactoryGirl.build :course
+      course.user_id = user.id
+      course.save
+      expect(courseitem.cloned_by_current_user?(user)).to eq false
+    end
+
+
+  end
+
+
+
+end

--- a/hammock/spec/requests/course_items.rb/course_items_spec.rb
+++ b/hammock/spec/requests/course_items.rb/course_items_spec.rb
@@ -1,5 +1,7 @@
 describe 'Courseitems API' do
 
+  render_views
+
   describe 'GET /courseitems' do
 
     it 'returns a JSON payload of course items' do

--- a/hammock/spec/requests/course_items.rb/course_items_spec.rb
+++ b/hammock/spec/requests/course_items.rb/course_items_spec.rb
@@ -1,6 +1,5 @@
 describe 'Courseitems API' do
 
-  render_views
 
   describe 'GET /courseitems' do
 
@@ -26,6 +25,22 @@ describe 'Courseitems API' do
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body.length).to eq((Courseitem.all.count))
+    end
+
+    it 'returns all courseitems with a cloned status' do
+      user = FactoryGirl.create :user
+      courseitem = FactoryGirl.create :courseitem
+      courseitem_uncloned = FactoryGirl.create :courseitem
+      course_one = Course.build_with_clone(courseitem, user)
+      course_one.save
+      auth_headers = user.create_new_auth_token
+
+      get "/courseitems", {}, auth_headers
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      p body
+      expect(body[0]["cloned"]).to eq true
+      expect(body[1]["cloned"]).to eq true
     end
 
   end


### PR DESCRIPTION
Implemented the clone check functionality which returns, in the json payload for courseitems, an additional node 'cloned' with a value of either true or false depending on whether or not the current user has added (cloned) that course into their own courses.

This includes an additional method on courseitem to check whether the courseitem has a clone in the user's courses, and a RABL template to render the additional node in the json payload.

All TDD'd and tests passing.
