### PR TITLE
show course route added and tested

### DIFF
--- a/hammock/app/controllers/courses_controller.rb
+++ b/hammock/app/controllers/courses_controller.rb
@@ -7,6 +7,11 @@ class CoursesController < ApplicationController
     render json: Course.where(user_id: current_user.id)
   end
 
+  def show
+    @course = Course.find(params[:id])
+    render json: @course
+  end
+
   def create
     @course = Course.build_with_user(course_params, current_user) unless course_params[:id]
     @course = Course.build_with_clone(Courseitem.find(course_params[:id]), current_user, course_params[:status]) if course_params[:id]

--- a/hammock/spec/requests/courses/courses_spec.rb
+++ b/hammock/spec/requests/courses/courses_spec.rb
@@ -57,6 +57,21 @@ describe "Courses API" do
     expect(body.length).to eq (2)
   end
 
+  it "return a single course" do
+    user = FactoryGirl.create :user
+    course1 = FactoryGirl.build :course
+    course1.user_id = user.id
+    course1.save
+
+    auth_headers = user.create_new_auth_token
+    get "/courses/#{course1.id}", {}, auth_headers
+
+    expect(response.status).to eq 200
+    body = JSON.parse(response.body)
+    expect(body["name"]).to eq course1.name
+    expect(body["image"]).to eq course1.image
+  end
+
   it "returns an error if the user is not signed in" do
     get "/courses", {}
     expect(response.status).to eq 401


### PR DESCRIPTION
adding a show route for 'courses/course_id' so that the course can be displayed on the module page.
